### PR TITLE
Proposal: Disable undefined reference (UR) rule in PMD

### DIFF
--- a/eclipse-java/pmd.xml
+++ b/eclipse-java/pmd.xml
@@ -54,4 +54,11 @@
       <property name="minimum" value="30" />
     </properties>
   </rule>
+  
+  <rule ref="category/java/errorprone.xml/DataflowAnomalyAnalysis">
+    <properties>
+      <property name="violationSuppressRegex"
+        value="^Found 'UR'-anomaly.*" />
+    </properties>
+  </rule>
 </ruleset>


### PR DESCRIPTION
The controversial PMD rule [DataflowAnomalyAnalysis](https://pmd.github.io/pmd-6.7.0/pmd_rules_java_errorprone.html#dataflowanomalyanalysis) contains a check for undefined references.

This check is unnecessary, since Eclipse itself will report the error and the Java compiler will eventually fail. Additionally, it has a high false positive rate. The following example would violate the rule:

```
for (final String role : rolesAllowed) {
  if (requestContext.getSecurityContext().isUserInRole(role)) {
     return;
    }
}
```

I propose to disable the UR section of the rule as shown in [this SO-post](https://stackoverflow.com/a/21608520/3250397).