### PR TITLE
Proposal: Allow pre-defined abbreviations in Checkstyle

### DIFF
--- a/eclipse-java/checkstyle.xml
+++ b/eclipse-java/checkstyle.xml
@@ -195,6 +195,7 @@
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false" />
       <property name="allowedAbbreviationLength" value="1" />
+      <property name="allowedAbbreviations" value="XML,URL"/>
     </module>
     <module name="OverloadMethodsDeclarationOrder" />
     <module name="VariableDeclarationUsageDistance" />


### PR DESCRIPTION
The Google checkstyle configuration uses `allowedAbbreviationLength = 1` for the `AbbreviationAsWordInName` rule. I have a class `CORSResponseFilter` that violates this rule, since the abbreviation `CORS` is too long.

The rule contains a [allowedAbbreviations property](http://checkstyle.sourceforge.net/config_naming.html#AbbreviationAsWordInName) that can handle exceptions to this rule.

Unfortunately, Checkstyle does not does not support overriding of previously defined rules at the moment (see [Checkstyle issue 2873](https://github.com/checkstyle/checkstyle/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+2873)). How should be proceed with this? 

I think we should modify the Google checkstyle rules, if all contributors (at the moment only @SoerenHenning) accept the modification.

Therefore I propose to add the `allowedAbbreviations` property with the default values `XML,URL` to the Google checkstyle section. Custom values can then be added, e.g., `CORS`.