### PR TITLE
Added SuppressionCommentFilter rule

### DIFF
--- a/eclipse-java/checkstyle.xml
+++ b/eclipse-java/checkstyle.xml
@@ -313,6 +313,14 @@
     <module name="SuppressWithNearbyCommentFilter">
       <property name="commentFormat" value="NOCS" />
     </module>
+            
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat"
+        value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat"
+        value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
 
     <!-- TODO - we require a rule to enforce only fqn for @link (afterwards, 
       UnusedImports->processJavadoc can be removed) - we require a rule to enforce 


### PR DESCRIPTION
This rule allows block-wide disabling of a specific Checkstyle rule, e.g.,

```
 // CHECKSTYLE.OFF: MultipleStringLiteralsCheck - Much more readable than NOCS in many lines

<Your 1000 lines of code>

  // CHECKSTYLE.ON: MultipleStringLiteralsCheck - Much more readable than NOCS in many lines
```