### PR TITLE
Proposal: No author tag in JavaDoc (Checkstyle)

### DIFF
--- a/eclipse-java/checkstyle.xml
+++ b/eclipse-java/checkstyle.xml
@@ -319,4 +319,14 @@
       declaring type arguments for generic types/methods -->
 
   </module>
+          
+   <module name="RegexpSingleline">
+    <property name="format" value="^\s*\*\s*@author" />
+    <property name="minimum" value="0" />
+    <property name="maximum" value="0" />
+    <property name="message"
+      value="Javadoc has illegal ''author'' tag." />
+    <property name="fileExtensions" value="java" />
+  </module>
+          
 </module>


### PR DESCRIPTION
Add no author tag rule for JavaDoc to Checkstyle. 

For reference, see:

- https://www.vojtechruzicka.com/stop-using-javadoc-author-tag/
- https://stackoverflow.com/questions/17269843/javadoc-author-tag-good-practices
- https://github.com/checkstyle/checkstyle/issues?utf8=%E2%9C%93&q=is%3Aissue+5339