### PR TITLE
Feature proposal / Update: Exclude DataClass rule and XML cleanup (PMD)

### DIFF
--- a/java/pmd.xml
+++ b/java/pmd.xml
@@ -1,43 +1,45 @@
 <?xml version="1.0"?>
 
 <ruleset name="CAU-SE Configuration"
-  xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
   xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
   <description>CAU-SE PMD ruleset</description>
 
-  <rule ref="category/java/bestpractices.xml">
+  <rule ref="category/java/bestpractices.xml" />
 
-  </rule>
   <rule ref="category/java/codestyle.xml">
     <exclude name="AtLeastOneConstructor" />
     <exclude name="OnlyOneReturn" />
     <exclude name="ShortVariable" />
     <exclude name="ShortClassName" />
   </rule>
+
   <rule ref="category/java/design.xml">
     <exclude name="LawOfDemeter" />
     <exclude name="LoosePackageCoupling" />
+    <exclude name="DataClass" />
   </rule>
+
   <rule ref="category/java/documentation.xml">
     <exclude name="CommentRequired" />
-
   </rule>
+
   <rule ref="category/java/errorprone.xml">
     <exclude name="BeanMembersShouldSerialize" />
-
   </rule>
+
   <rule ref="category/java/multithreading.xml">
     <exclude name="AvoidUsingVolatile" />
     <exclude name="UseConcurrentHashMap" />
     <exclude name="DoNotUseThreads" />
-
   </rule>
+
   <rule ref="category/java/performance.xml">
     <exclude name="SimplifyStartsWith" />
   </rule>
   <rule ref="category/java/security.xml">
-
   </rule>
 
   <!-- Adjustments -->
@@ -54,7 +56,7 @@
       <property name="minimum" value="30" />
     </properties>
   </rule>
-  
+
   <rule ref="category/java/errorprone.xml/DataflowAnomalyAnalysis">
     <properties>
       <property name="violationSuppressRegex"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- \[x] Indentation settings (No tabs, 2 spaces)
- \[x] PR title follows one of these patterns (Tool name is optional, if PR does contain general changes)
  - Bug fix: Short description (Tool name)
  - Feature proposal: Short description (Tool name)
  - Update: Short description (Tool name)
  - *New-not-mentioned-type*: Short description (Tool name)

* **What kind of change does this PR introduce?** (Bug fix, feature proposal, (docs) update, ...)   
Feature proposal and Update

* **What is the current behavior?** (You can also link to an open issue here)   
PMD reports violations of the [DataClass rule](https://pmd.github.io/pmd-6.4.0/pmd_rules_java_design.html#dataclass), e.g., for [this simple POJO](https://github.com/ExplorViz/explorviz-backend/blob/multi-project/shared/src/main/java/net/explorviz/shared/security/User.java)

* **What is the new behavior?**   
Disabling the DataClass rule will prevent this stupid violation.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)   
Not a breaking change, but projects using an old version of the PMD configuration might want to update the conf file.

* **How has this change been tested?**   
Manually tested in project [ExplorViz](https://github.com/ExplorViz/explorviz-backend/blob/multi-project/conf/pmd.xml#L22)

---

**Reviewer checklist**
- [x] Pulled branch, manually tested
- [x] Reviewed indentation
